### PR TITLE
Handle signed weight and bias data paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,16 @@
 Utilising Machine Learning tools to help weight the onboard neural networks on our custom FPGA system to deliver decision-critical information at ultra-low latencies. 
 
 ## Hardware building blocks
-The `verilog/` directory contains synthesizable Verilog-2001 modules that implement key neural-network accelerator blocks for radar signal processing:
+The `verilog/` directory contains synthesizable SystemVerilog modules that implement key neural-network accelerator blocks for radar signal processing:
 
 | Module | Description |
 | --- | --- |
-| `mac_unit.v` | Fixed-point multiply–accumulate with pipelined multiplier and configurable fractional precision. Includes a simple self-checking testbench. |
-| `relu_activation.v` | Signed ReLU activation with valid/ready style timing and accompanying testbench. |
-| `weight_bias_regfile.v` | Configurable weight and bias register file with independent write controls plus a smoke-test bench. |
-| `stream_register.v` | One-stage ready/valid stream register that can wrap existing datapaths and an illustrative testbench. |
-| `neural_network_top.v` | Example top-level pipeline that chains MAC and ReLU layers, backed by the register file for weights/biases, with a streaming interface and demo testbench. |
+| `mac_unit.sv` | Fixed-point multiply–accumulate with pipelined multiplier and configurable fractional precision. Includes a simple self-checking testbench. |
+| `relu_activation.sv` | Signed ReLU activation with valid/ready style timing and accompanying testbench. |
+| `weight_bias_regfile.sv` | Configurable weight and bias register file with independent write controls plus a smoke-test bench. |
+| `stream_register.sv` | One-stage ready/valid stream register that can wrap existing datapaths and an illustrative testbench. |
+| `neural_network_top.sv` | Example top-level pipeline that chains MAC and ReLU layers, backed by the register file for weights/biases, with a streaming interface and demo testbench. |
 
-Each file includes an example testbench that can be simulated with your preferred Verilog simulator (e.g., `iverilog` or `xsim`).
+Each file includes an example testbench that can be simulated with your preferred SystemVerilog-capable simulator (e.g., `iverilog` or `xsim`).
+
+These designs are intended for Intel Cyclone V (5CSEMA5F31C6) devices; synthesis and fitting can be performed with recent Quartus Prime releases.

--- a/verilog/mac_unit.sv
+++ b/verilog/mac_unit.sv
@@ -5,40 +5,42 @@ module mac_unit #(
     parameter integer ACC_WIDTH  = 32,
     parameter integer FRAC_BITS  = 8
 ) (
-    input  wire                          clk,
-    input  wire                          rst,
-    input  wire                          ce,
-    input  wire                          valid_in,
-    input  wire signed [DATA_WIDTH-1:0]  a,
-    input  wire signed [DATA_WIDTH-1:0]  b,
-    input  wire signed [ACC_WIDTH-1:0]   acc_in,
-    output reg                           valid_out,
-    output reg  signed [ACC_WIDTH-1:0]   acc_out
+    input  logic                          clk,
+    input  logic                          rst,
+    input  logic                          ce,
+    input  logic                          valid_in,
+    input  logic signed [DATA_WIDTH-1:0]  a,
+    input  logic signed [DATA_WIDTH-1:0]  b,
+    input  logic signed [ACC_WIDTH-1:0]   acc_in,
+    output logic                          valid_out,
+    output logic signed [ACC_WIDTH-1:0]   acc_out
 );
     localparam integer PROD_WIDTH = DATA_WIDTH * 2;
 
-    reg signed [PROD_WIDTH-1:0] mult_pipe;
-    reg signed [ACC_WIDTH-1:0]  acc_pipe;
-    reg                         valid_pipe;
+    logic signed [PROD_WIDTH-1:0] mult_pipe;
+    logic signed [ACC_WIDTH-1:0]  acc_pipe;
+    logic                         valid_pipe;
 
-    function [ACC_WIDTH-1:0] sign_resize;
-        input signed [PROD_WIDTH-1:0] value;
-        begin
-            if (ACC_WIDTH >= PROD_WIDTH) begin
-                sign_resize = {{(ACC_WIDTH-PROD_WIDTH){value[PROD_WIDTH-1]}}, value};
-            end else begin
-                sign_resize = value[PROD_WIDTH-1 -: ACC_WIDTH];
-            end
+    function automatic logic signed [ACC_WIDTH-1:0] sign_resize(
+        input logic signed [PROD_WIDTH-1:0] value
+    );
+        if (ACC_WIDTH >= PROD_WIDTH) begin
+            sign_resize = {{(ACC_WIDTH-PROD_WIDTH){value[PROD_WIDTH-1]}}, value};
+        end else begin
+            sign_resize = value[PROD_WIDTH-1 -: ACC_WIDTH];
         end
     endfunction
 
-    wire signed [PROD_WIDTH-1:0] product_shifted = mult_pipe >>> FRAC_BITS;
-    wire signed [ACC_WIDTH-1:0]  mult_scaled     = $signed(sign_resize(product_shifted));
+    logic signed [PROD_WIDTH-1:0] product_shifted;
+    logic signed [ACC_WIDTH-1:0]  mult_scaled;
 
-    always @(posedge clk) begin
+    assign product_shifted = mult_pipe >>> FRAC_BITS;
+    assign mult_scaled     = $signed(sign_resize(product_shifted));
+
+    always_ff @(posedge clk) begin
         if (rst) begin
-            mult_pipe  <= {PROD_WIDTH{1'b0}};
-            acc_pipe   <= {ACC_WIDTH{1'b0}};
+            mult_pipe  <= '0;
+            acc_pipe   <= '0;
             valid_pipe <= 1'b0;
         end else if (ce) begin
             if (valid_in) begin
@@ -49,9 +51,9 @@ module mac_unit #(
         end
     end
 
-    always @(posedge clk) begin
+    always_ff @(posedge clk) begin
         if (rst) begin
-            acc_out   <= {ACC_WIDTH{1'b0}};
+            acc_out   <= '0;
             valid_out <= 1'b0;
         end else if (ce) begin
             if (valid_pipe) begin
@@ -67,16 +69,16 @@ module tb_mac_unit;
     localparam integer ACC_WIDTH  = 32;
     localparam integer FRAC_BITS  = 8;
 
-    reg clk = 1'b0;
-    reg rst = 1'b1;
-    reg ce  = 1'b1;
+    logic clk = 1'b0;
+    logic rst = 1'b1;
+    logic ce  = 1'b1;
 
-    reg  valid_in = 1'b0;
-    reg  signed [DATA_WIDTH-1:0] a = 0;
-    reg  signed [DATA_WIDTH-1:0] b = 0;
-    reg  signed [ACC_WIDTH-1:0]  acc_in = 0;
-    wire signed [ACC_WIDTH-1:0]  acc_out;
-    wire valid_out;
+    logic        valid_in = 1'b0;
+    logic signed [DATA_WIDTH-1:0] a = '0;
+    logic signed [DATA_WIDTH-1:0] b = '0;
+    logic signed [ACC_WIDTH-1:0]  acc_in = '0;
+    logic signed [ACC_WIDTH-1:0]  acc_out;
+    logic        valid_out;
 
     mac_unit #(
         .DATA_WIDTH(DATA_WIDTH),
@@ -115,16 +117,16 @@ module tb_mac_unit;
 
         @(posedge clk);
         valid_in <= 1'b0;
-        a        <= 0;
-        b        <= 0;
-        acc_in   <= 0;
+        a        <= '0;
+        b        <= '0;
+        acc_in   <= '0;
 
         repeat (6) @(posedge clk);
         $display("MAC unit testbench end");
         $finish;
     end
 
-    always @(posedge clk) begin
+    always_ff @(posedge clk) begin
         if (valid_out) begin
             $display("[%0t] acc_out = %0d", $time, acc_out);
         end

--- a/verilog/neural_network_top.sv
+++ b/verilog/neural_network_top.sv
@@ -7,22 +7,22 @@ module neural_network_top #(
     parameter integer LAYER_COUNT       = 3,
     parameter integer LAYER_ADDR_WIDTH  = 2
 ) (
-    input  wire                          clk,
-    input  wire                          rst,
-    input  wire                          ce,
-    input  wire                          in_valid,
-    output wire                          in_ready,
-    input  wire signed [DATA_WIDTH-1:0]  in_data,
-    output wire                          out_valid,
-    output wire signed [DATA_WIDTH-1:0]  out_data,
-    input  wire                          cfg_weight_we,
-    input  wire [LAYER_ADDR_WIDTH-1:0]   cfg_weight_addr,
-    input  wire [DATA_WIDTH-1:0]         cfg_weight_data,
-    input  wire                          cfg_bias_we,
-    input  wire [LAYER_ADDR_WIDTH-1:0]   cfg_bias_addr,
-    input  wire [DATA_WIDTH-1:0]         cfg_bias_data,
-    input  wire                          cfg_commit,
-    output wire                          cfg_busy
+    input  logic                         clk,
+    input  logic                         rst,
+    input  logic                         ce,
+    input  logic                         in_valid,
+    output logic                         in_ready,
+    input  logic signed [DATA_WIDTH-1:0] in_data,
+    output logic                         out_valid,
+    output logic signed [DATA_WIDTH-1:0] out_data,
+    input  logic                         cfg_weight_we,
+    input  logic [LAYER_ADDR_WIDTH-1:0]  cfg_weight_addr,
+    input  logic signed [DATA_WIDTH-1:0] cfg_weight_data,
+    input  logic                         cfg_bias_we,
+    input  logic [LAYER_ADDR_WIDTH-1:0]  cfg_bias_addr,
+    input  logic signed [DATA_WIDTH-1:0] cfg_bias_data,
+    input  logic                         cfg_commit,
+    output logic                         cfg_busy
 );
     initial begin
         if (LAYER_COUNT <= 0) begin
@@ -30,8 +30,8 @@ module neural_network_top #(
         end
     end
 
-    wire input_stage_valid;
-    wire signed [DATA_WIDTH-1:0] input_stage_data;
+    logic                         input_stage_valid;
+    logic signed [DATA_WIDTH-1:0] input_stage_data;
 
     stream_register #(
         .DATA_WIDTH(DATA_WIDTH)
@@ -47,21 +47,21 @@ module neural_network_top #(
         .out_data(input_stage_data)
     );
 
-    reg signed [DATA_WIDTH-1:0] layer_weight_reg [0:LAYER_COUNT-1];
-    reg signed [DATA_WIDTH-1:0] layer_bias_reg   [0:LAYER_COUNT-1];
+    logic signed [DATA_WIDTH-1:0] layer_weight_reg [0:LAYER_COUNT-1];
+    logic signed [DATA_WIDTH-1:0] layer_bias_reg   [0:LAYER_COUNT-1];
 
-    reg [LAYER_ADDR_WIDTH-1:0] copy_addr;
-    reg                        copy_active;
-    reg                        copy_phase;
+    logic [LAYER_ADDR_WIDTH-1:0] copy_addr;
+    logic                        copy_active;
+    logic                        copy_phase;
 
     integer i;
-    always @(posedge clk) begin
+    always_ff @(posedge clk) begin
         if (rst) begin
             for (i = 0; i < LAYER_COUNT; i = i + 1) begin
-                layer_weight_reg[i] <= {DATA_WIDTH{1'b0}};
-                layer_bias_reg[i]   <= {DATA_WIDTH{1'b0}};
+                layer_weight_reg[i] <= '0;
+                layer_bias_reg[i]   <= '0;
             end
-            copy_addr   <= {LAYER_ADDR_WIDTH{1'b0}};
+            copy_addr   <= '0;
             copy_active <= 1'b0;
             copy_phase  <= 1'b0;
         end else if (ce) begin
@@ -69,7 +69,7 @@ module neural_network_top #(
                 if (cfg_commit) begin
                     copy_active <= 1'b1;
                     copy_phase  <= 1'b0;
-                    copy_addr   <= {LAYER_ADDR_WIDTH{1'b0}};
+                    copy_addr   <= '0;
                 end
             end else begin
                 if (!copy_phase) begin
@@ -91,8 +91,8 @@ module neural_network_top #(
 
     assign cfg_busy = copy_active;
 
-    wire [DATA_WIDTH-1:0] weight_read_data;
-    wire [DATA_WIDTH-1:0] bias_read_data;
+    logic signed [DATA_WIDTH-1:0] weight_read_data;
+    logic signed [DATA_WIDTH-1:0] bias_read_data;
 
     weight_bias_regfile #(
         .DATA_WIDTH(DATA_WIDTH),
@@ -116,15 +116,14 @@ module neural_network_top #(
         .bias_read_data(bias_read_data)
     );
 
-    function signed [DATA_WIDTH-1:0] acc_to_data;
-        input signed [ACC_WIDTH-1:0] value;
-        begin
-            acc_to_data = value >>> FRAC_BITS;
-        end
+    function automatic signed [DATA_WIDTH-1:0] acc_to_data(
+        input signed [ACC_WIDTH-1:0] value
+    );
+        acc_to_data = value >>> FRAC_BITS;
     endfunction
 
-    wire signed [DATA_WIDTH-1:0] layer_data [0:LAYER_COUNT];
-    wire                         layer_valid [0:LAYER_COUNT];
+    logic signed [DATA_WIDTH-1:0] layer_data [0:LAYER_COUNT];
+    logic                         layer_valid [0:LAYER_COUNT];
 
     assign layer_data[0]  = input_stage_data;
     assign layer_valid[0] = input_stage_valid;
@@ -132,10 +131,13 @@ module neural_network_top #(
     genvar layer_idx;
     generate
         for (layer_idx = 0; layer_idx < LAYER_COUNT; layer_idx = layer_idx + 1) begin : g_layers
-            wire signed [ACC_WIDTH-1:0] mac_acc;
-            wire                        mac_valid;
-            wire signed [ACC_WIDTH-1:0] bias_extended = $signed(layer_bias_reg[layer_idx]) <<< FRAC_BITS;
-            wire signed [DATA_WIDTH-1:0] mac_scaled = acc_to_data(mac_acc);
+            logic signed [ACC_WIDTH-1:0] mac_acc;
+            logic                        mac_valid;
+            logic signed [ACC_WIDTH-1:0] bias_extended;
+            logic signed [DATA_WIDTH-1:0] mac_scaled;
+
+            assign bias_extended = $signed(layer_bias_reg[layer_idx]) <<< FRAC_BITS;
+            assign mac_scaled    = acc_to_data(mac_acc);
 
             mac_unit #(
                 .DATA_WIDTH(DATA_WIDTH),
@@ -178,24 +180,24 @@ module tb_neural_network_top;
     localparam integer LAYER_COUNT      = 3;
     localparam integer LAYER_ADDR_WIDTH = 2;
 
-    reg clk = 1'b0;
-    reg rst = 1'b1;
-    reg ce  = 1'b1;
+    logic clk = 1'b0;
+    logic rst = 1'b1;
+    logic ce  = 1'b1;
 
-    reg  in_valid = 1'b0;
-    wire in_ready;
-    reg  signed [DATA_WIDTH-1:0] in_data = 0;
-    wire out_valid;
-    wire signed [DATA_WIDTH-1:0] out_data;
+    logic                         in_valid = 1'b0;
+    logic                         in_ready;
+    logic signed [DATA_WIDTH-1:0] in_data = '0;
+    logic                         out_valid;
+    logic signed [DATA_WIDTH-1:0] out_data;
 
-    reg cfg_weight_we = 1'b0;
-    reg cfg_bias_we   = 1'b0;
-    reg [LAYER_ADDR_WIDTH-1:0] cfg_weight_addr = 0;
-    reg [LAYER_ADDR_WIDTH-1:0] cfg_bias_addr   = 0;
-    reg [DATA_WIDTH-1:0] cfg_weight_data = 0;
-    reg [DATA_WIDTH-1:0] cfg_bias_data   = 0;
-    reg cfg_commit = 1'b0;
-    wire cfg_busy;
+    logic cfg_weight_we = 1'b0;
+    logic cfg_bias_we   = 1'b0;
+    logic [LAYER_ADDR_WIDTH-1:0] cfg_weight_addr = '0;
+    logic [LAYER_ADDR_WIDTH-1:0] cfg_bias_addr   = '0;
+    logic signed [DATA_WIDTH-1:0] cfg_weight_data = '0;
+    logic signed [DATA_WIDTH-1:0] cfg_bias_data   = '0;
+    logic cfg_commit = 1'b0;
+    logic cfg_busy;
 
     neural_network_top #(
         .DATA_WIDTH(DATA_WIDTH),
@@ -224,28 +226,26 @@ module tb_neural_network_top;
 
     always #5 clk = ~clk;
 
-    task write_weight;
-        input [LAYER_ADDR_WIDTH-1:0] addr;
-        input [DATA_WIDTH-1:0] data;
-        begin
-            cfg_weight_addr <= addr;
-            cfg_weight_data <= data;
-            cfg_weight_we   <= 1'b1;
-            @(posedge clk);
-            cfg_weight_we   <= 1'b0;
-        end
+    task automatic write_weight(
+        input [LAYER_ADDR_WIDTH-1:0] addr,
+        input signed [DATA_WIDTH-1:0] data
+    );
+        cfg_weight_addr <= addr;
+        cfg_weight_data <= data;
+        cfg_weight_we   <= 1'b1;
+        @(posedge clk);
+        cfg_weight_we   <= 1'b0;
     endtask
 
-    task write_bias;
-        input [LAYER_ADDR_WIDTH-1:0] addr;
-        input [DATA_WIDTH-1:0] data;
-        begin
-            cfg_bias_addr <= addr;
-            cfg_bias_data <= data;
-            cfg_bias_we   <= 1'b1;
-            @(posedge clk);
-            cfg_bias_we   <= 1'b0;
-        end
+    task automatic write_bias(
+        input [LAYER_ADDR_WIDTH-1:0] addr,
+        input signed [DATA_WIDTH-1:0] data
+    );
+        cfg_bias_addr <= addr;
+        cfg_bias_data <= data;
+        cfg_bias_we   <= 1'b1;
+        @(posedge clk);
+        cfg_bias_we   <= 1'b0;
     endtask
 
     initial begin
@@ -295,7 +295,7 @@ module tb_neural_network_top;
         $finish;
     end
 
-    always @(posedge clk) begin
+    always_ff @(posedge clk) begin
         if (out_valid) begin
             $display("[%0t] Output sample = %0d", $time, out_data);
         end

--- a/verilog/relu_activation.sv
+++ b/verilog/relu_activation.sv
@@ -3,22 +3,22 @@
 module relu_activation #(
     parameter integer DATA_WIDTH = 16
 ) (
-    input  wire                          clk,
-    input  wire                          rst,
-    input  wire                          ce,
-    input  wire                          valid_in,
-    input  wire signed [DATA_WIDTH-1:0]  in_data,
-    output reg                           valid_out,
-    output reg  signed [DATA_WIDTH-1:0]  out_data
+    input  logic                         clk,
+    input  logic                         rst,
+    input  logic                         ce,
+    input  logic                         valid_in,
+    input  logic signed [DATA_WIDTH-1:0] in_data,
+    output logic                         valid_out,
+    output logic signed [DATA_WIDTH-1:0] out_data
 );
-    always @(posedge clk) begin
+    always_ff @(posedge clk) begin
         if (rst) begin
-            out_data  <= {DATA_WIDTH{1'b0}};
+            out_data  <= '0;
             valid_out <= 1'b0;
         end else if (ce) begin
             if (valid_in) begin
                 if (in_data[DATA_WIDTH-1]) begin
-                    out_data <= {DATA_WIDTH{1'b0}};
+                    out_data <= '0;
                 end else begin
                     out_data <= in_data;
                 end
@@ -31,14 +31,14 @@ endmodule
 module tb_relu_activation;
     localparam integer DATA_WIDTH = 16;
 
-    reg clk = 1'b0;
-    reg rst = 1'b1;
-    reg ce  = 1'b1;
+    logic clk = 1'b0;
+    logic rst = 1'b1;
+    logic ce  = 1'b1;
 
-    reg  valid_in = 1'b0;
-    reg  signed [DATA_WIDTH-1:0] in_data = 0;
-    wire signed [DATA_WIDTH-1:0] out_data;
-    wire valid_out;
+    logic        valid_in = 1'b0;
+    logic signed [DATA_WIDTH-1:0] in_data = '0;
+    logic signed [DATA_WIDTH-1:0] out_data;
+    logic        valid_out;
 
     relu_activation #(
         .DATA_WIDTH(DATA_WIDTH)
@@ -80,7 +80,7 @@ module tb_relu_activation;
         $finish;
     end
 
-    always @(posedge clk) begin
+    always_ff @(posedge clk) begin
         if (valid_out) begin
             $display("[%0t] out_data = %0d", $time, out_data);
         end

--- a/verilog/stream_register.sv
+++ b/verilog/stream_register.sv
@@ -3,22 +3,22 @@
 module stream_register #(
     parameter integer DATA_WIDTH = 32
 ) (
-    input  wire                  clk,
-    input  wire                  rst,
-    input  wire                  ce,
-    input  wire                  in_valid,
-    output wire                  in_ready,
-    input  wire [DATA_WIDTH-1:0] in_data,
-    output reg                   out_valid,
-    input  wire                  out_ready,
-    output reg  [DATA_WIDTH-1:0] out_data
+    input  logic                  clk,
+    input  logic                  rst,
+    input  logic                  ce,
+    input  logic                  in_valid,
+    output logic                  in_ready,
+    input  logic [DATA_WIDTH-1:0] in_data,
+    output logic                  out_valid,
+    input  logic                  out_ready,
+    output logic [DATA_WIDTH-1:0] out_data
 );
     assign in_ready = ce ? (~out_valid || out_ready) : 1'b0;
 
-    always @(posedge clk) begin
+    always_ff @(posedge clk) begin
         if (rst) begin
             out_valid <= 1'b0;
-            out_data  <= {DATA_WIDTH{1'b0}};
+            out_data  <= '0;
         end else if (ce) begin
             case ({in_valid && in_ready, out_valid && out_ready})
                 2'b00: begin
@@ -43,17 +43,17 @@ endmodule
 module tb_stream_register;
     localparam integer DATA_WIDTH = 16;
 
-    reg clk = 1'b0;
-    reg rst = 1'b1;
-    reg ce  = 1'b1;
+    logic clk = 1'b0;
+    logic rst = 1'b1;
+    logic ce  = 1'b1;
 
-    reg  in_valid = 1'b0;
-    reg  [DATA_WIDTH-1:0] in_data = 0;
-    wire in_ready;
+    logic                  in_valid = 1'b0;
+    logic [DATA_WIDTH-1:0] in_data  = '0;
+    logic                  in_ready;
 
-    wire out_valid;
-    reg  out_ready = 1'b0;
-    wire [DATA_WIDTH-1:0] out_data;
+    logic                  out_valid;
+    logic                  out_ready = 1'b0;
+    logic [DATA_WIDTH-1:0] out_data;
 
     stream_register #(
         .DATA_WIDTH(DATA_WIDTH)
@@ -77,8 +77,8 @@ module tb_stream_register;
         rst <= 1'b0;
 
         @(posedge clk);
-        in_valid <= 1'b1;
-        in_data  <= 16'h0001;
+        in_valid  <= 1'b1;
+        in_data   <= 16'h0001;
         out_ready <= 1'b0;
 
         @(posedge clk);
@@ -101,7 +101,7 @@ module tb_stream_register;
         $finish;
     end
 
-    always @(posedge clk) begin
+    always_ff @(posedge clk) begin
         $display("[%0t] in_valid=%b in_ready=%b out_valid=%b out_ready=%b out_data=%0h",
                  $time, in_valid, in_ready, out_valid, out_ready, out_data);
     end

--- a/verilog/weight_bias_regfile.sv
+++ b/verilog/weight_bias_regfile.sv
@@ -7,35 +7,35 @@ module weight_bias_regfile #(
     parameter integer WEIGHT_ADDR_WIDTH  = 6,
     parameter integer BIAS_ADDR_WIDTH    = 4
 ) (
-    input  wire                          clk,
-    input  wire                          rst,
-    input  wire                          ce,
-    input  wire                          weight_we,
-    input  wire [WEIGHT_ADDR_WIDTH-1:0]  weight_write_addr,
-    input  wire [DATA_WIDTH-1:0]         weight_write_data,
-    input  wire                          bias_we,
-    input  wire [BIAS_ADDR_WIDTH-1:0]    bias_write_addr,
-    input  wire [DATA_WIDTH-1:0]         bias_write_data,
-    input  wire [WEIGHT_ADDR_WIDTH-1:0]  weight_read_addr,
-    input  wire [BIAS_ADDR_WIDTH-1:0]    bias_read_addr,
-    output reg  [DATA_WIDTH-1:0]         weight_read_data,
-    output reg  [DATA_WIDTH-1:0]         bias_read_data
+    input  logic                          clk,
+    input  logic                          rst,
+    input  logic                          ce,
+    input  logic                          weight_we,
+    input  logic [WEIGHT_ADDR_WIDTH-1:0]  weight_write_addr,
+    input  logic signed [DATA_WIDTH-1:0]  weight_write_data,
+    input  logic                          bias_we,
+    input  logic [BIAS_ADDR_WIDTH-1:0]    bias_write_addr,
+    input  logic signed [DATA_WIDTH-1:0]  bias_write_data,
+    input  logic [WEIGHT_ADDR_WIDTH-1:0]  weight_read_addr,
+    input  logic [BIAS_ADDR_WIDTH-1:0]    bias_read_addr,
+    output logic signed [DATA_WIDTH-1:0]  weight_read_data,
+    output logic signed [DATA_WIDTH-1:0]  bias_read_data
 );
-    reg [DATA_WIDTH-1:0] weight_mem [0:WEIGHT_COUNT-1];
-    reg [DATA_WIDTH-1:0] bias_mem   [0:BIAS_COUNT-1];
+    logic signed [DATA_WIDTH-1:0] weight_mem [0:WEIGHT_COUNT-1];
+    logic signed [DATA_WIDTH-1:0] bias_mem   [0:BIAS_COUNT-1];
 
     integer i;
 
-    always @(posedge clk) begin
+    always_ff @(posedge clk) begin
         if (rst) begin
             for (i = 0; i < WEIGHT_COUNT; i = i + 1) begin
-                weight_mem[i] <= {DATA_WIDTH{1'b0}};
+                weight_mem[i] <= '0;
             end
             for (i = 0; i < BIAS_COUNT; i = i + 1) begin
-                bias_mem[i] <= {DATA_WIDTH{1'b0}};
+                bias_mem[i] <= '0;
             end
-            weight_read_data <= {DATA_WIDTH{1'b0}};
-            bias_read_data   <= {DATA_WIDTH{1'b0}};
+            weight_read_data <= '0;
+            bias_read_data   <= '0;
         end else if (ce) begin
             if (weight_we) begin
                 weight_mem[weight_write_addr] <= weight_write_data;
@@ -56,20 +56,20 @@ module tb_weight_bias_regfile;
     localparam integer WEIGHT_ADDR_WIDTH = 2;
     localparam integer BIAS_ADDR_WIDTH   = 1;
 
-    reg clk = 1'b0;
-    reg rst = 1'b1;
-    reg ce  = 1'b1;
+    logic clk = 1'b0;
+    logic rst = 1'b1;
+    logic ce  = 1'b1;
 
-    reg  weight_we = 1'b0;
-    reg  bias_we   = 1'b0;
-    reg  [WEIGHT_ADDR_WIDTH-1:0] weight_write_addr = 0;
-    reg  [BIAS_ADDR_WIDTH-1:0]   bias_write_addr   = 0;
-    reg  [DATA_WIDTH-1:0]        weight_write_data = 0;
-    reg  [DATA_WIDTH-1:0]        bias_write_data   = 0;
-    reg  [WEIGHT_ADDR_WIDTH-1:0] weight_read_addr  = 0;
-    reg  [BIAS_ADDR_WIDTH-1:0]   bias_read_addr    = 0;
-    wire [DATA_WIDTH-1:0]        weight_read_data;
-    wire [DATA_WIDTH-1:0]        bias_read_data;
+    logic                         weight_we = 1'b0;
+    logic                         bias_we   = 1'b0;
+    logic [WEIGHT_ADDR_WIDTH-1:0] weight_write_addr = '0;
+    logic [BIAS_ADDR_WIDTH-1:0]   bias_write_addr   = '0;
+    logic signed [DATA_WIDTH-1:0] weight_write_data = '0;
+    logic signed [DATA_WIDTH-1:0] bias_write_data   = '0;
+    logic [WEIGHT_ADDR_WIDTH-1:0] weight_read_addr  = '0;
+    logic [BIAS_ADDR_WIDTH-1:0]   bias_read_addr    = '0;
+    logic signed [DATA_WIDTH-1:0] weight_read_data;
+    logic signed [DATA_WIDTH-1:0] bias_read_data;
 
     weight_bias_regfile #(
         .DATA_WIDTH(DATA_WIDTH),
@@ -127,7 +127,7 @@ module tb_weight_bias_regfile;
         $finish;
     end
 
-    always @(posedge clk) begin
+    always_ff @(posedge clk) begin
         if (!rst) begin
             $display("[%0t] weight_rd=%0h bias_rd=%0h", $time, weight_read_data, bias_read_data);
         end


### PR DESCRIPTION
## Summary
- treat weight and bias data paths as signed throughout the register file and top-level neural network wrapper
- align configuration testbench helpers with signed weight/bias values for correct fixed-point behavior
- document Cyclone V 5CSEMA5F31C6 as the target FPGA for synthesis

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c92269c0483248a58809c88e8ea6e)